### PR TITLE
Echeck/ACH transaction types and CreditCard refactoring

### DIFF
--- a/src/Integrations/Payment/Type/CommonMethods.php
+++ b/src/Integrations/Payment/Type/CommonMethods.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace roundhouse\formbuilderintegrations\Integrations\Payment\Type;
+
+use roundhouse\formbuilder\FormBuilder;
+
+trait CommonMethods {
+  /**
+   * Helper function to test if field contains a value
+   */
+  private function hasValueInField($field) {
+    if (isset($this->integration[$field]) && $this->entry->{$this->integration[$field]} != '') {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Helper function to retrieve value from complex fields
+   */
+  private function getValueFromField($field) {
+    $value = $this->entry->{$this->integration[$field]};
+
+    if (is_object($value) && property_exists(get_class($value), 'value')) {
+      $value = $value->value;
+    }
+
+    if ('ccNumberField' === $field) { //XXX: Remove white characters from CC number
+      $value = preg_replace('/\s+/', '', $value);
+    }
+
+    return $value;
+  }
+
+  private function validateRequired($field, $field_label) {
+    if (!$this->hasValueInField($field)) {
+      $this->entry->addError($this->integration[$field], FormBuilder::t($field_label.' is required'));
+
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/Integrations/Payment/Type/CreditCard.php
+++ b/src/Integrations/Payment/Type/CreditCard.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace roundhouse\formbuilderintegrations\Integrations\Payment\Type;
+
+use Craft;
+
+use roundhouse\formbuilder\FormBuilder;
+use roundhouse\formbuilder\elements\Entry;
+use roundhouse\formbuilder\elements\Form;
+
+use Omnipay\Converge\Gateway;
+use Omnipay\Common\CreditCard as OmnipayCreditCard;
+use Omnipay\Common\Helper;
+use Omnipay\Converge\Message\Response as OmnipayResponse;
+
+use Money\Currency;
+use Pachico\Magoo\Magoo;
+use craft\helpers\Json;
+use craft\helpers\DateTimeHelper;
+
+use roundhouse\formbuilderintegrations\models\Converge as ConvergeModel;
+use roundhouse\formbuilderintegrations\records\Converge as ConvergeRecord;
+
+class CreditCard implements Type {
+  use CommonMethods;
+
+  private $gateway;
+  private $currency;
+  private $entry;
+  private $integration;
+
+  public function __construct(Gateway $gateway, Currency $currency, Entry $entry, array $integration) {
+    $this->gateway     = $gateway;
+    $this->currency    = $currency;
+    $this->entry       = $entry;
+    $this->integration = $integration;
+  }
+
+  public function isValid() {
+    $is_valid = true;
+
+    if (!$this->validateRequired('ccExpirationMonthField', 'Expiration month')) {
+      $is_valid = false;
+    }
+
+    if (!$this->validateRequired('ccExpirationYearField', 'Expiration year')) {
+      $is_valid = false;
+    }
+
+    if (!$this->validateRequired('ccNumberField', 'Card number')) {
+      $is_valid = false;
+    }
+
+    if (!$this->validateRequired('ccAmountField', 'Amount')) {
+      $is_valid = false;
+    }
+
+    if (!$this->validateCreditCardNumber()) {
+      $is_valid = false;
+    }
+
+    if (!$this->validateExpirationDate()) {
+      $is_valid = false;
+    }
+
+    return $is_valid;
+  }
+
+  private function validateCreditCardNumber() {
+    $cardNumber = $this->getValueFromField('ccNumberField');
+
+    if (
+      is_null($cardNumber) ||
+      !is_numeric($cardNumber) ||
+      !Helper::validateLuhn($cardNumber)
+    ) {
+        $this->entry->addError($this->integration['ccNumberField'], FormBuilder::t('Card number is invalid'));
+
+        return false;
+    }
+
+    if (!preg_match('/^\d{12,19}$/i', $cardNumber)) {
+        $this->entry->addError($this->integration['ccNumberField'], FormBuilder::t('Card number should have 12 to 19 digits'));
+
+        return false;
+    }
+
+    return true;
+  }
+
+  private function validateExpirationDate() {
+    $expiration = $this->getValueFromField('ccExpirationYearField').$this->getValueFromField('ccExpirationMonthField');
+
+    if ($expiration < gmdate('Ym')) {
+      $this->entry->addError($this->integration['ccNumberField'], FormBuilder::t('Card has expired'));
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private function buildCreditCard() {
+    if ($this->isValid()) {
+      $cc = new OmnipayCreditCard();
+      $cc->setExpiryMonth($this->getValueFromField('ccExpirationMonthField'));
+      $cc->setExpiryYear($this->getValueFromField('ccExpirationYearField'));
+      $cc->setNumber($this->getValueFromField('ccNumberField'));
+      if ($this->hasValueInField('ccCvcField')) {
+        $cc->setCvv($this->getValueFromField('ccCvcField'));
+      }
+      if ($this->hasValueInField('firstNameField')) {
+        $cc->setFirstName($this->getValueFromField('firstNameField'));
+      }
+      if ($this->hasValueInField('lastNameField')) {
+        $cc->setLastName($this->getValueFromField('lastNameField'));
+      }
+      if ($this->hasValueInField('emailField')) {
+        $cc->setEmail($this->getValueFromField('emailField'));
+      }
+      if ($this->hasValueInField('phoneField')) {
+        $cc->setPhone($this->getValueFromField('phoneField'));
+      }
+
+      return $cc;
+    }
+
+    return null;
+  }
+
+  public function getTransaction() {
+    $cc  = $this->buildCreditCard();
+    if (null === $cc) {
+      throw new \Exception('Could not create transaction due to some errors, please run "isValid" for details.');
+    }
+
+    $params = [
+        'amount'    => $this->getValueFromField('ccAmountField'),
+        'currency'  => $this->currency,
+        'card'      => $cc
+    ];
+
+    switch ($this->integration['transactionType']) {
+      case 'ccsale':
+        return $this->gateway->purchase($params);
+        break;
+      case 'ccauthonly':
+        return $this->gateway->purchase($params);
+        break;
+      default:
+        return null;
+        break;
+    }
+
+    return null;
+  }
+
+  public function handleSuccess(OmnipayResponse $response, Form $form) {
+    FormBuilder::info('Integration Converge payment success! ' . $response->getMessage());
+
+    try {
+        $this->maskCredentials($form);
+    } catch(\Throwable $e) {
+        FormBuilder::error('Integration Converge normalizing fields and changing title failed! ' . $e);
+    }
+
+    $data = $response->getData();
+
+    $model = new ConvergeModel();
+    $model->integrationId = $this->integration['integrationId'];
+    $model->amount = $data['ssl_amount'];
+    $model->currency = $this->currency->getCode();
+    $model->last4 = substr($data['ssl_card_number'], -4);
+    $model->status = $response->getMessage();
+    $model->metadata = Json::encode($data);
+
+    $record = new ConvergeRecord();
+    $record->integrationId = $model->integrationId;
+    $record->amount = $model->amount;
+    $record->currency = $model->currency;
+    $record->last4 = $model->last4;
+    $record->status = $model->status;
+    $record->metadata = $model->metadata;
+
+    return [$model, $record];
+  }
+
+  public function handleFailure(OmnipayResponse $response, Form $form) {
+    $this->maskCredentials();
+
+    if ($response->getCode() === '4007') {
+      $field = Craft::$app->fields->getFieldByHandle($this->converge['ccCvcField']);
+      $this->entry->addError($this->converge['ccCvcField'], FormBuilder::t($field->name . ' is required'));
+    }
+
+    if ($response->getCode() === '4025') {
+      $this->entry->addError($this->converge['ccCvcField'], FormBuilder::t($response->getMessage()));
+    }
+
+    FormBuilder::error('Integration Converge payment failed! ' . $response->getMessage());
+  }
+
+  private function maskCredentials(Form $form)
+  {
+      $magoo = new Magoo();
+      $magoo->maskCreditCards();
+
+      $this->entry->{$this->converge['ccNumberField']} = $magoo->getMasked($this->entry->{$this->converge['ccNumberField']});
+      $this->entry->{$this->converge['ccCvcField']} = '***';
+
+      $postFields = $_POST['fields'];
+      foreach ($postFields as $handle => $field) {
+        if ($this->converge['ccNumberField'] === $handle) {
+          $postFields[$this->converge['ccNumberField']] = $magoo->getMasked($this->entry->{$this->converge['ccNumberField']});
+        }
+
+        if ($this->converge['ccCvcField'] === $handle) {
+          $postFields[$this->converge['ccCvcField']] = '***';
+        }
+      }
+      $title = isset($form->settings['database']['titleFormat']) && $form->settings['database']['titleFormat'] != '' ? $form->settings['database']['titleFormat'] : 'Submission - '.DateTimeHelper::currentTimeStamp();
+
+      $this->entry->title = Craft::$app->getView()->renderObjectTemplate($title, $postFields);
+  }
+}

--- a/src/Integrations/Payment/Type/ECheckACH.php
+++ b/src/Integrations/Payment/Type/ECheckACH.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace roundhouse\formbuilderintegrations\Integrations\Payment\Type;
+
+use roundhouse\formbuilder\elements\Entry;
+use roundhouse\formbuilder\elements\Form;
+
+use Omnipay\Converge\Gateway;
+use Omnipay\Common\CreditCard as OmnipayCreditCard;
+use Omnipay\Common\Helper;
+use Omnipay\Converge\Message\Response as OmnipayResponse;
+
+use Money\Currency;
+
+class ECheckACH implements Type {
+  use CommonMethods;
+
+  private $gateway;
+  private $currency;
+  private $entry;
+  private $integration;
+
+  public function __construct(Gateway $gateway, Currency $currency, Entry $entry, array $integration) {
+    $this->gateway     = $gateway;
+    $this->currency    = $currency;
+    $this->entry       = $entry;
+    $this->integration = $integration;
+  }
+
+  public function isValid() {
+    $is_valid = true;
+
+    $required = [
+      ['achAmount', 'Amount'],
+      ['achAbaNumber', 'AbaNumber'],
+      ['achBankAccountNumber', 'BankAccountNumber'],
+      ['achBankAccountType', 'BankAccountType'],
+      ['achAgree', 'Agree'],
+      ['achCompany', 'Company'],
+      ['achFirstName', 'FirstName'],
+      ['achLastName', 'LastName'],
+    ];
+
+    foreach ($required as $conf) {
+      if (!$this->validateRequired($conf[0], $conf[1])) {
+        $is_valid = false;
+      }
+    }
+
+    return $is_valid;
+  }
+
+  public function getTransaction() {
+    $params = [
+      'amount'                  => $this->getValueFromField('achAmount'),
+      'currency'                => $this->currency,
+      'ssl_aba_number'          => $this->getValueFromField('achAbaNumber'),
+      'ssl_bank_account_number' => $this->getValueFromField('achBankAccountNumber'),
+      'ssl_bank_account_type'   => $this->getValueFromField('achBankAccountType'),
+      'ssl_agree'               => $this->getValueFromField('achAgree'),
+      'ssl_first_name'          => $this->getValueFromField('achFirstName'),
+      'ssl_last_name'           => $this->getValueFromField('achLastName'),
+      'ssl_company'             => $this->getValueFromField('achCompany'),
+    ];
+
+    return $this->gateway->purchase($params);
+  }
+
+  public function handleSuccess(OmnipayResponse $response, Form $form) {
+    return null;
+  }
+  public function handleFailure(OmnipayResponse $response, Form $form) {
+    return null;
+  }
+}

--- a/src/Integrations/Payment/Type/Type.php
+++ b/src/Integrations/Payment/Type/Type.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace roundhouse\formbuilderintegrations\Integrations\Payment\Type;
+
+interface Type {
+  public function isValid();
+  public function getTransaction();
+}

--- a/src/templates/types/converge/_edit.twig
+++ b/src/templates/types/converge/_edit.twig
@@ -27,6 +27,16 @@
                     </div>
                 </div>
 
+                <div class="fb-field" id="field-type">
+                    <div class="input-hint">TYPE</div>
+                    <div class="select">
+                        <select name="settings[type]">
+                            <option value="CreditCard" {% if entry.settings['type'] == 'CreditCard' %}selected{% endif %}>Credit card</option>
+                            <option value="ECheckACH" {% if entry.settings['type'] == 'ECheckACH' %}selected{% endif %}>ECheck / ACH</option>
+                        </select>
+                    </div>
+                </div>
+
                 <div class="fb-field" id="field-pin">
                     <div class="input-hint">TEST MODE</div>
                     <div class="select">

--- a/src/templates/types/converge/fields/ach-aba-number.twig
+++ b/src/templates/types/converge/fields/ach-aba-number.twig
@@ -1,0 +1,44 @@
+{% import "form-builder/_includes/_components" as components %}
+
+{% set availableFields = form.fieldLayoutId is defined and form.fieldLayoutId ? craft.app.getFields.getLayoutById(form.fieldLayoutId).getFields() : null %}
+{% set fieldsOption = [] %}
+{% set fieldsOption = [{'label': 'Select Field', 'value': ''}] %}
+{% for field in availableFields %}
+    {% set fieldsOption = fieldsOption|merge([{ 'label': field.name, 'value': field.handle }]) %}
+{% endfor %}
+
+{% set nameText = 'integrations[converge][achAbaNumber]' %}
+
+{% set container = {
+    title: 'ABA Number Field' |t,
+    info: null,
+    icon: null,
+    toggle: false,
+    class: null,
+    id: null
+} %}
+
+{% set inputs = {
+    0: {
+        type: 'select',
+        name: nameText,
+        value: form.integrations.converge.achAbaNumber is defined and form.integrations.converge.achAbaNumber != '' ? form.integrations.converge.achAbaNumber : '',
+        options: fieldsOption |json_encode(),
+        class: 'hidden',
+        id: null,
+        hint: 'FIELD'
+    }
+} %}
+
+{% set modal = {
+    title: 'ABA Number Field' |t,
+    instructions: 'Routing/Transit Number as printed on the Check.' |t,
+    successMessage: 'ABA Number Field Mapped' |t,
+    inputs: inputs
+} %}
+
+{{ components.optionItem(
+    container,
+    modal,
+    inputs
+) }}

--- a/src/templates/types/converge/fields/ach-agree.twig
+++ b/src/templates/types/converge/fields/ach-agree.twig
@@ -1,0 +1,44 @@
+{% import "form-builder/_includes/_components" as components %}
+
+{% set availableFields = form.fieldLayoutId is defined and form.fieldLayoutId ? craft.app.getFields.getLayoutById(form.fieldLayoutId).getFields() : null %}
+{% set fieldsOption = [] %}
+{% set fieldsOption = [{'label': 'Select Field', 'value': ''}] %}
+{% for field in availableFields %}
+    {% set fieldsOption = fieldsOption|merge([{ 'label': field.name, 'value': field.handle }]) %}
+{% endfor %}
+
+{% set nameText = 'integrations[converge][achAgree]' %}
+
+{% set container = {
+    title: 'Agree Field' |t,
+    info: null,
+    icon: null,
+    toggle: false,
+    class: null,
+    id: null
+} %}
+
+{% set inputs = {
+    0: {
+        type: 'select',
+        name: nameText,
+        value: form.integrations.converge.achAgree is defined and form.integrations.converge.achAgree != '' ? form.integrations.converge.achAgree : '',
+        options: fieldsOption |json_encode(),
+        class: 'hidden',
+        id: null,
+        hint: 'FIELD'
+    }
+} %}
+
+{% set modal = {
+    title: 'Agree Field' |t,
+    instructions: 'The agreement flag. One numeric digit value, valid values are: 1 for I agree, 0 for I do not Agree.' |t,
+    successMessage: 'Agree Field Mapped' |t,
+    inputs: inputs
+} %}
+
+{{ components.optionItem(
+    container,
+    modal,
+    inputs
+) }}

--- a/src/templates/types/converge/fields/ach-amount.twig
+++ b/src/templates/types/converge/fields/ach-amount.twig
@@ -1,0 +1,44 @@
+{% import "form-builder/_includes/_components" as components %}
+
+{% set availableFields = form.fieldLayoutId is defined and form.fieldLayoutId ? craft.app.getFields.getLayoutById(form.fieldLayoutId).getFields() : null %}
+{% set fieldsOption = [] %}
+{% set fieldsOption = [{'label': 'Select Field', 'value': ''}] %}
+{% for field in availableFields %}
+    {% set fieldsOption = fieldsOption|merge([{ 'label': field.name, 'value': field.handle }]) %}
+{% endfor %}
+
+{% set nameText = 'integrations[converge][achAmount]' %}
+
+{% set container = {
+    title: 'Amount Field' |t,
+    info: null,
+    icon: null,
+    toggle: false,
+    class: null,
+    id: null
+} %}
+
+{% set inputs = {
+    0: {
+        type: 'select',
+        name: nameText,
+        value: form.integrations.converge.achAmount is defined and form.integrations.converge.achAmount != '' ? form.integrations.converge.achAmount : '',
+        options: fieldsOption |json_encode(),
+        class: 'hidden',
+        id: null,
+        hint: 'FIELD'
+    }
+} %}
+
+{% set modal = {
+    title: 'Amount Field' |t,
+    instructions: 'Transaction Sale Amount. Must be number with 2 decimal places. This amount does not include the tip amount which must be sent separately if needed.' |t,
+    successMessage: 'Amount Field Mapped' |t,
+    inputs: inputs
+} %}
+
+{{ components.optionItem(
+    container,
+    modal,
+    inputs
+) }}

--- a/src/templates/types/converge/fields/ach-bank-account-number.twig
+++ b/src/templates/types/converge/fields/ach-bank-account-number.twig
@@ -1,0 +1,44 @@
+{% import "form-builder/_includes/_components" as components %}
+
+{% set availableFields = form.fieldLayoutId is defined and form.fieldLayoutId ? craft.app.getFields.getLayoutById(form.fieldLayoutId).getFields() : null %}
+{% set fieldsOption = [] %}
+{% set fieldsOption = [{'label': 'Select Field', 'value': ''}] %}
+{% for field in availableFields %}
+    {% set fieldsOption = fieldsOption|merge([{ 'label': field.name, 'value': field.handle }]) %}
+{% endfor %}
+
+{% set nameText = 'integrations[converge][achBankAccountNumber]' %}
+
+{% set container = {
+    title: 'Bank account number' |t,
+    info: null,
+    icon: null,
+    toggle: false,
+    class: null,
+    id: null
+} %}
+
+{% set inputs = {
+    0: {
+        type: 'select',
+        name: nameText,
+        value: form.integrations.converge.achBankAccountNumber is defined and form.integrations.converge.achBankAccountNumber != '' ? form.integrations.converge.achBankAccountNumber : '',
+        options: fieldsOption |json_encode(),
+        class: 'hidden',
+        id: null,
+        hint: 'FIELD'
+    }
+} %}
+
+{% set modal = {
+    title: 'Bank account number Field' |t,
+    instructions: 'Bank account number as printed on the Check. Not applicable for Paper Check conversion.' |t,
+    successMessage: 'Bank account number Field Mapped' |t,
+    inputs: inputs
+} %}
+
+{{ components.optionItem(
+    container,
+    modal,
+    inputs
+) }}

--- a/src/templates/types/converge/fields/ach-bank-account-type.twig
+++ b/src/templates/types/converge/fields/ach-bank-account-type.twig
@@ -1,0 +1,44 @@
+{% import "form-builder/_includes/_components" as components %}
+
+{% set availableFields = form.fieldLayoutId is defined and form.fieldLayoutId ? craft.app.getFields.getLayoutById(form.fieldLayoutId).getFields() : null %}
+{% set fieldsOption = [] %}
+{% set fieldsOption = [{'label': 'Select Field', 'value': ''}] %}
+{% for field in availableFields %}
+    {% set fieldsOption = fieldsOption|merge([{ 'label': field.name, 'value': field.handle }]) %}
+{% endfor %}
+
+{% set nameText = 'integrations[converge][achBankAccountType]' %}
+
+{% set container = {
+    title: 'Bank account type' |t,
+    info: null,
+    icon: null,
+    toggle: false,
+    class: null,
+    id: null
+} %}
+
+{% set inputs = {
+    0: {
+        type: 'select',
+        name: nameText,
+        value: form.integrations.converge.achBankAccountType is defined and form.integrations.converge.achBankAccountType != '' ? form.integrations.converge.achBankAccountType : '',
+        options: fieldsOption |json_encode(),
+        class: 'hidden',
+        id: null,
+        hint: 'FIELD'
+    }
+} %}
+
+{% set modal = {
+    title: 'Bank account type Field' |t,
+    instructions: 'The bank account type. One numeric digit value, valid values are: 0 for Personal, 1 for Business.' |t,
+    successMessage: 'Bank account type Field Mapped' |t,
+    inputs: inputs
+} %}
+
+{{ components.optionItem(
+    container,
+    modal,
+    inputs
+) }}

--- a/src/templates/types/converge/fields/ach-company.twig
+++ b/src/templates/types/converge/fields/ach-company.twig
@@ -1,0 +1,44 @@
+{% import "form-builder/_includes/_components" as components %}
+
+{% set availableFields = form.fieldLayoutId is defined and form.fieldLayoutId ? craft.app.getFields.getLayoutById(form.fieldLayoutId).getFields() : null %}
+{% set fieldsOption = [] %}
+{% set fieldsOption = [{'label': 'Select Field', 'value': ''}] %}
+{% for field in availableFields %}
+    {% set fieldsOption = fieldsOption|merge([{ 'label': field.name, 'value': field.handle }]) %}
+{% endfor %}
+
+{% set nameText = 'integrations[converge][achCompany]' %}
+
+{% set container = {
+    title: 'Company Field' |t,
+    info: null,
+    icon: null,
+    toggle: false,
+    class: null,
+    id: null
+} %}
+
+{% set inputs = {
+    0: {
+        type: 'select',
+        name: nameText,
+        value: form.integrations.converge.achCompany is defined and form.integrations.converge.achCompany != '' ? form.integrations.converge.achCompany : '',
+        options: fieldsOption |json_encode(),
+        class: 'hidden',
+        id: null,
+        hint: 'FIELD'
+    }
+} %}
+
+{% set modal = {
+    title: 'Company Field' |t,
+    instructions: 'Required for ACH ECheck with Business Checks. Company Name.' |t,
+    successMessage: 'Company Field Mapped' |t,
+    inputs: inputs
+} %}
+
+{{ components.optionItem(
+    container,
+    modal,
+    inputs
+) }}

--- a/src/templates/types/converge/fields/ach-first-name.twig
+++ b/src/templates/types/converge/fields/ach-first-name.twig
@@ -1,0 +1,44 @@
+{% import "form-builder/_includes/_components" as components %}
+
+{% set availableFields = form.fieldLayoutId is defined and form.fieldLayoutId ? craft.app.getFields.getLayoutById(form.fieldLayoutId).getFields() : null %}
+{% set fieldsOption = [] %}
+{% set fieldsOption = [{'label': 'Select Field', 'value': ''}] %}
+{% for field in availableFields %}
+    {% set fieldsOption = fieldsOption|merge([{ 'label': field.name, 'value': field.handle }]) %}
+{% endfor %}
+
+{% set nameText = 'integrations[converge][achFirstName]' %}
+
+{% set container = {
+    title: 'First name Field' |t,
+    info: null,
+    icon: null,
+    toggle: false,
+    class: null,
+    id: null
+} %}
+
+{% set inputs = {
+    0: {
+        type: 'select',
+        name: nameText,
+        value: form.integrations.converge.achFirstName is defined and form.integrations.converge.achFirstName != '' ? form.integrations.converge.achFirstName : '',
+        options: fieldsOption |json_encode(),
+        class: 'hidden',
+        id: null,
+        hint: 'FIELD'
+    }
+} %}
+
+{% set modal = {
+    title: 'First name Field' |t,
+    instructions: 'Required for ACH ECheck with Personal Checks. The Consumer first name. Alphanumeric.' |t,
+    successMessage: 'First name Field Mapped' |t,
+    inputs: inputs
+} %}
+
+{{ components.optionItem(
+    container,
+    modal,
+    inputs
+) }}

--- a/src/templates/types/converge/fields/ach-last-name.twig
+++ b/src/templates/types/converge/fields/ach-last-name.twig
@@ -1,0 +1,44 @@
+{% import "form-builder/_includes/_components" as components %}
+
+{% set availableFields = form.fieldLayoutId is defined and form.fieldLayoutId ? craft.app.getFields.getLayoutById(form.fieldLayoutId).getFields() : null %}
+{% set fieldsOption = [] %}
+{% set fieldsOption = [{'label': 'Select Field', 'value': ''}] %}
+{% for field in availableFields %}
+    {% set fieldsOption = fieldsOption|merge([{ 'label': field.name, 'value': field.handle }]) %}
+{% endfor %}
+
+{% set nameText = 'integrations[converge][achLastName]' %}
+
+{% set container = {
+    title: 'Last name Field' |t,
+    info: null,
+    icon: null,
+    toggle: false,
+    class: null,
+    id: null
+} %}
+
+{% set inputs = {
+    0: {
+        type: 'select',
+        name: nameText,
+        value: form.integrations.converge.achLastName is defined and form.integrations.converge.achLastName != '' ? form.integrations.converge.achLastName : '',
+        options: fieldsOption |json_encode(),
+        class: 'hidden',
+        id: null,
+        hint: 'FIELD'
+    }
+} %}
+
+{% set modal = {
+    title: 'Last name Field' |t,
+    instructions: 'Required for ACH ECheck with Personal Checks. The Consumer last name.' |t,
+    successMessage: 'Last name Field Mapped' |t,
+    inputs: inputs
+} %}
+
+{{ components.optionItem(
+    container,
+    modal,
+    inputs
+) }}

--- a/src/templates/types/converge/fields/ach-transaction-type.twig
+++ b/src/templates/types/converge/fields/ach-transaction-type.twig
@@ -1,13 +1,7 @@
 {% import "form-builder/_includes/_components" as components %}
 
 {% set fieldsOption = [
-    {'label': 'ECheck/ACH Sale', 'value': 'ecspurchase'},
-    {'label': 'CC Sale', 'value': 'ccsale'},
-    {'label': 'CC Auth Only', 'value': 'ccauthonly'},
-    {'label': 'CC Return', 'value': 'ccreturn'},
-    {'label': 'CC Void', 'value': 'ccvoid'},
-    {'label': 'CC Verify', 'value': 'ccverify'},
-    {'label': 'CC Generate Token', 'value': 'ccgettoken'},
+    {'label': 'Sale', 'value': 'ecspurchase'},
 ] %}
 
 {% set nameText = 'integrations[converge][transactionType]' %}

--- a/src/templates/types/converge/form.twig
+++ b/src/templates/types/converge/form.twig
@@ -51,6 +51,16 @@
         <h3>{{ 'Options'|t('form-builder') }}</h3>
     </div>
 
+    <div class="fb-field" id="field-type">
+        <div class="input-hint">TYPE</div>
+        <div class="select">
+            <select name="settings[type]">
+                <option value="CreditCard">Credit card</option>
+                <option value="ECheckACH">ECheck / ACH</option>
+            </select>
+        </div>
+    </div>
+
     <div class="fb-field" id="field-test-mode">
         <div class="input-hint">TEST MODE</div>
         <div class="select">

--- a/src/templates/types/converge/integration-section.twig
+++ b/src/templates/types/converge/integration-section.twig
@@ -28,7 +28,22 @@
 
     <div class="body">
         <div class="fields">
-            {% include templatePath ~ 'transaction-type' ignore missing %}
+          {% include templatePath ~ 'transaction-type' ignore missing %}
+          {% if "ECheckACH" == integration.settings.type %}
+            {% include templatePath ~ 'ach-aba-number' ignore missing %}
+            {% include templatePath ~ 'ach-bank-account-number' ignore missing %}
+            {% include templatePath ~ 'ach-agree' ignore missing %}
+            {% include templatePath ~ 'ach-amount' ignore missing %}
+            {% include templatePath ~ 'ach-bank-account-type' ignore missing %}
+            {% include templatePath ~ 'ach-first-name' ignore missing %}
+            {% include templatePath ~ 'ach-last-name' ignore missing %}
+            {% include templatePath ~ 'ach-company' ignore missing %}
+
+
+{#
+ssl_company	C	
+#}
+          {% else %}
             {% include templatePath ~ 'cc-number-field' ignore missing %}
             {% include templatePath ~ 'cc-cvc-field' ignore missing %}
             {% include templatePath ~ 'cc-expiration-field' ignore missing %}
@@ -37,6 +52,7 @@
             {% include templatePath ~ 'cc-name-field' ignore missing %}
             {% include templatePath ~ 'cc-email-field' ignore missing %}
             {% include templatePath ~ 'cc-phone-field' ignore missing %}
+          {% endif %}
         </div>
     </div>
 


### PR DESCRIPTION
The main feature is: ECheck/ACH support.

It required some refactoring / changes though.

When creating integration, once can pick "type" (ECheckACH or CreditCard), then it's the same flow: mapping fields etc.

The code requires updated Omnipay lib, see https://github.com/owldesign/omnipay-converge/pull/1

